### PR TITLE
Add metadata to results file.

### DIFF
--- a/linpack/linpack_extra/run_linpack.sh
+++ b/linpack/linpack_extra/run_linpack.sh
@@ -16,6 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+TOOLS_BIN="/"
 max_threads=0
 threads_to_do=0
 iterations=5
@@ -33,6 +34,8 @@ cpus_in_sock=""
 GOMP_CPU_AFFINITY=""
 NUMB_SOCKETS=""
 reduce_only=0
+test_name="linpack"
+test_version="1.0"
 
 out_dir=`pwd`/linpack_results
 if [[ -d "$out_dir" ]]; then
@@ -171,9 +174,9 @@ process_summary()
 	ls | cut -d'.' -f1-5 | sort -u > /tmp/linpack_temp
 	iters=0
 	input="/tmp/linpack_temp"
-	test_name="linpack"
 
-	echo hyper_config:sockets:threads:unit:"MB/sec:cpu_affin" > results_${test_name}.csv
+	$TOOLS_BIN/test_header_info --front_matter --results_file results_${test_name}.csv  $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $test_version --test_name $test_name
+	echo hyper_config:sockets:threads:unit:"MB/sec:cpu_affin" >> results_${test_name}.csv
 
 	while IFS= read -r lin_file
 	do
@@ -253,13 +256,14 @@ usage()
 	echo "  -i: value: number of iterationsto run"
 	echo "  -n: numactl interleave"
 	echo "  -s: sanity run"
+	echo "  -T: Tools bin to find test_header_info in"
 	echo "  -t: max threads: maximum number of threads"
 	exit 1
 }
 
 show_config=0
 
-while getopts "RC:ci:t:h:P:s:u:oS:n:" opt; do
+while getopts "RC:ci:t:h:P:s:u:oS:n:T:" opt; do
 	case ${opt} in
 		C)
 			config=${OPTARG}
@@ -284,6 +288,9 @@ while getopts "RC:ci:t:h:P:s:u:oS:n:" opt; do
 		;;
 		R)
 			reduce_only=1
+		;;
+		T)
+			TOOLS_BIN=${OPTARG}
 		;;
 		t)
 			threads_list=${OPTARG}

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -201,16 +201,16 @@ execute_via_shell()
 			test_config=`echo "${linpack_ops}" | cut -d':' -f 1`
 			config="${to_configuration}_${test_config}"
 			cd $run_dir/${test_name}
-			echo ./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave
-			./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
+			echo ./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave
+			./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
 			if [ $? -ne 0 ]; then
 				error_exit "run_linpack.sh failed" 1
 			fi
 		done  < "$file"
 	else
 		cd $run_dir/${test_name}
-		echo ./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname  -n $interleave
-		./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
+		echo ./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname  -n $interleave
+		./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
 		if [ $? -ne 0 ]; then
 			error_exit "run_linpack.sh failed" 1
 		fi
@@ -279,6 +279,7 @@ chmod 755 ${run_dir}/linpack/xlinpack_xeon64
 # Gather hardware information
 ${curdir}/test_tools/gather_data ${curdir}
 
+rm -rf $run_dir/linpack/linpack_results  $run_dir/linpack/results*
 for iteration in  `seq 1 1 $to_times_to_run`
 do
 	out_file=/tmp/${test_name}_${to_tuned_setting}_numa_interleave_${interleave}_iteration_$iteration.out


### PR DESCRIPTION
Add metadata to results file.
Remove prior results before running to prevent multiple entrys in the results file, including metadata.