### PR TITLE
Adding test results validation by regexp

### DIFF
--- a/linpack/base_test_results/test1/verify
+++ b/linpack/base_test_results/test1/verify
@@ -1,0 +1,4 @@
+%_header
+ht_config:sockets:threads:unit:MB/sec:cpu_affin
+%_multiples
+:[[:digit:]]{1,}:[[:digit:]]{1,}:GFlops:[[:digit:]]{1,}:[ 0-9,]{1,}$

--- a/linpack/linpack_extra/run_linpack.sh
+++ b/linpack/linpack_extra/run_linpack.sh
@@ -32,6 +32,7 @@ GOMP_CPU_AFFINITY=""
 NUMB_SOCKETS=""
 reduce_only=0
 test_name="linpack"
+results_file="results_${test_name}.csv"
 test_version="1.0"
 
 out_dir=`pwd`/linpack_results
@@ -173,8 +174,8 @@ process_summary()
 	iters=0
 	input="/tmp/linpack_temp"
 
-	$TOOLS_BIN/test_header_info --front_matter --results_file results.csv  $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $test_version --test_name $test_name
-	echo ht_config:sockets:threads:unit:"MB/sec:cpu_affin" >> results.csv
+	$TOOLS_BIN/test_header_info --front_matter --results_file $results_file  $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $test_version --test_name $test_name
+	echo ht_config:sockets:threads:unit:"MB/sec:cpu_affin" >> $results_file
 
 	while IFS= read -r lin_file
 	do
@@ -219,7 +220,7 @@ process_summary()
 		done < "$input1"
 		if [[ $avg  != "" ]]; then
 			test_results="Ran"
-			echo $ht_setting:$sockets:$threads:$unit:$avg:$cpu_affin >> results.csv
+			echo $ht_setting:$sockets:$threads:$unit:$avg:$cpu_affin >> $results_file
 		fi
 	done < "$input"
 

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -38,6 +38,8 @@ usage()
 }
 
 test_name="linpack"
+results_file="results_${test_name}.csv"
+
 if [ ! -f "/tmp/${test_name}.out" ]; then
         command="${0} $@"
         echo $command
@@ -319,7 +321,13 @@ if [ $use_pbench_version -eq 1 ]; then
 	copy_pbench_data
 else
 	if [ $to_pbench -eq 0 ]; then
-		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results linpack_results/results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "linpack_results/test_results_report,${curdir}/hw_info.out"
+		$TOOLS_BIN/validate_line --results_file linpack_results/$results_file --base_results_file $run_dir/base_test_results/test1/verify
+		if [[ $? -eq 0 ]]; then
+			echo Ran >> linpack_results/test_results_report
+		else
+			echo Failed >> linpack_results/test_results_report
+		fi
+		${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results linpack_results/$results_file --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "linpack_results/test_results_report,${curdir}/hw_info.out"
 
 	fi
 fi

--- a/linpack/verification_config/test_verify
+++ b/linpack/verification_config/test_verify
@@ -1,0 +1,4 @@
+Required_Systems: intel,amd,arm
+Via_Zathras: No
+test:--interleave all --iterations 1:base_test_results/test1/verify
+


### PR DESCRIPTION
# Description
This adds the required files and hooks into the wrapper for verification of the test results via regexp.

# Before/After Comparison
Before change: Failures will occur on validation
After change: Passes when it should, fails when it should.

# Clerical Stuff
This closes #22 

Relates to JIRA: RPOPC-348

# Testing
Running the wrapper (modifying the regexps to force failures)
Verified test fails when it has bad data
Verified test passes when we have good data.
