### PR TITLE
Adding PCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ General options
   --tuned_setting: used in naming the tar file, default for RHEL is the current active tuned.  For non
     RHEL systems, default is none.
   --usage: this usage message.
+  --use_pcp: Enables use of Performance Co-Pilot in wrappers, defaults to 0.
 ```

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -229,14 +229,43 @@ chmod 755 ${run_dir}/linpack/xlinpack_xeon64
 ${curdir}/test_tools/gather_data ${curdir}
 
 rm -rf $run_dir/linpack/linpack_results  $run_dir/linpack/results*
+
+# Get PCP setup if we're using it
+pdir=""
+if [[ $to_use_pcp -eq 1 ]]; then
+	source $TOOLS_BIN/pcp/pcp_commands.inc
+	setup_pcp
+	pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+	pcpdir=/tmp/pcp_`date "+%Y.%m.%d-%H.%M.%S"`
+	pdir="--copy_dir $pcpdir"
+	start_pcp ${pcpdir}/ ${test_name} $pcp_cfg
+fi
+
 for iteration in  `seq 1 1 $to_times_to_run`
 do
+#If we're using PCP, snap a chalk line at the start of the iteration
+	if [[ $to_use_pcp -eq 1 ]]; then
+		start_pcp_subset
+	fi
 	out_file=/tmp/${test_name}_${to_tuned_setting}_numa_interleave_${interleave}_iteration_$iteration.out
 	execute_via_shell
+	# If we're using PCP, snap the chalk line at the end of the iteration
+	# and log the iteration's result
+
+	if [[ $to_use_pcp -eq 1 ]]; then
+		echo "Send result to PCP archive"
+		echo ${iteration}
+		result2pcp iteration_number ${iteration}
+		stop_pcp_subset
+	fi
 done
+
+if [[ $to_use_pcp -eq 1 ]]; then
+	shutdown_pcp
+fi
 
 #
 # Process the data.
 #
-${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results linpack_results/results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "linpack_results/test_results_report,${curdir}/hw_info.out"
+${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results linpack_results/results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "linpack_results/test_results_report,${curdir}/hw_info.out" $pdir
 exit 0


### PR DESCRIPTION
# Description
PR removed pbench and adds PCP support to linpack wrapper

# Before/After Comparison
Wrapper no longer uses pbench and uses PCP support

This closes #29 

Relates to JIRA: RPOPC-633
