### PR TITLE
Save test metrics to openmetrics

### DIFF
--- a/linpack/linpack_extra/run_linpack.sh
+++ b/linpack/linpack_extra/run_linpack.sh
@@ -225,7 +225,7 @@ process_summary()
 		done < "$input1"
 		if [[ $avg  != "" ]]; then
 			test_results="Ran"
-			data_string=$(build_data_string "$ht_setting" "$sockets" "$threads" "$unit" "$avg" "$cpu_affin" "$start_time" "$end_time")
+			data_string=$(build_data_string "$ht_setting" "$sockets" "$threads" "$unit" "$avg" "$cpu_affin")
 
 			echo "$data_string" >> results.csv
 		fi

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -261,13 +261,17 @@ do
 		while IFS= read -r line
 		do
 			value=`echo $line | cut -d: -f1`
+			#
+			# Note: If we ever get to having more then 2 hyperthreads in the future, this
+			# will need to be updated.  For now value of 1 indicates 2 hyperthreads.
+			#
 			if [[ $value == *"yes"* ]]; then
 				results2pcp_add_value "hyper_thread:1"
 			else
 				results2pcp_add_value "hyper_thread:0"
 			fi
 			value=`echo $line | cut -d, -f2`
-			results2pcp_add_value "numb_sockets:$value"
+			results2pcp_add_value "num_sockets:$value"
 			value=`echo $line | cut -d, -f3`
 			results2pcp_add_value "numthreads:$value"
 			value=`echo $line | cut -d, -f5`

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -21,6 +21,7 @@
 # This script automates the execution of linpack.  It will determine the
 # set of default run parameters based on the system configuration.
 #
+
 error_exit()
 {
 	echo $1
@@ -253,14 +254,39 @@ do
 	# and log the iteration's result
 
 	if [[ $to_use_pcp -eq 1 ]]; then
-		echo "Send result to PCP archive"
-		echo ${iteration}
-		result2pcp iteration_number ${iteration}
+		linpack_data=`mktemp /tmp/passmark_data.XXXXX`
+		results2pcp_add_value "iteration:${iteration}"
+		grep ^ht linpack_results/results.csv  | grep -v cpu_affin > $linpack_data
+		while IFS= read -r line
+		do
+			value=`echo $line | cut -d: -f1`
+			if [[ $value == *"yes"* ]]; then
+				results2pcp_add_value "hyper_thread:1"
+			else
+				results2pcp_add_value "hyper_thread:0"
+			fi
+			value=`echo $line | cut -d: -f2`
+			results2pcp_add_value "numb_sockets:$value"
+			value=`echo $line | cut -d: -f3`
+			results2pcp_add_value "numthreads:$value"
+			value=`echo $line | cut -d: -f5`
+			results2pcp_add_value "gflops:$value"
+			#
+			# Commit the metrics
+			#
+			results2pcp_add_value_commit
+		done < "${linpack_data}"
+		rm $linpack_data
+		#
+		# Reset metrics
+		#
+		reset_pcp_om
 		stop_pcp_subset
 	fi
 done
 
 if [[ $to_use_pcp -eq 1 ]]; then
+	stop_pcp
 	shutdown_pcp
 fi
 

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -132,6 +132,7 @@ fi
 
 ${curdir}/test_tools/gather_data ${curdir}
 source test_tools/general_setup "$@"
+export TOOLS_BIN
 
 execute_via_shell()
 {
@@ -156,16 +157,16 @@ execute_via_shell()
 			test_config=`echo "${linpack_ops}" | cut -d':' -f 1`
 			config="${to_configuration}_${test_config}"
 			cd $run_dir/${test_name}
-			echo ./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave
-			./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
+			echo ./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave
+			./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
 			if [ $? -ne 0 ]; then
 				error_exit "run_linpack.sh failed" 1
 			fi
 		done  < "$file"
 	else
 		cd $run_dir/${test_name}
-		echo ./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname  -n $interleave
-		./run_linpack.sh -T $TOOLS_BIN -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
+		echo ./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname  -n $interleave
+		./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
 		if [ $? -ne 0 ]; then
 			error_exit "run_linpack.sh failed" 1
 		fi
@@ -265,11 +266,11 @@ do
 			else
 				results2pcp_add_value "hyper_thread:0"
 			fi
-			value=`echo $line | cut -d: -f2`
+			value=`echo $line | cut -d, -f2`
 			results2pcp_add_value "numb_sockets:$value"
-			value=`echo $line | cut -d: -f3`
+			value=`echo $line | cut -d, -f3`
 			results2pcp_add_value "numthreads:$value"
-			value=`echo $line | cut -d: -f5`
+			value=`echo $line | cut -d, -f5`
 			results2pcp_add_value "gflops:$value"
 			#
 			# Commit the metrics

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -255,7 +255,7 @@ do
 	# and log the iteration's result
 
 	if [[ $to_use_pcp -eq 1 ]]; then
-		linpack_data=`mktemp /tmp/passmark_data.XXXXX`
+		linpack_data=`mktemp /tmp/linpack_data.XXXXX`
 		results2pcp_add_value "iteration:${iteration}"
 		grep ^ht linpack_results/results.csv  | grep -v cpu_affin > $linpack_data
 		while IFS= read -r line

--- a/linpack/openmetrics_linpack_reset.txt
+++ b/linpack/openmetrics_linpack_reset.txt
@@ -1,0 +1,9 @@
+iteration 0
+running 0
+numthreads 0
+runtime NaN
+throughput NaN
+latency NaN
+hyper_thread NaN
+numb_sockets NaN
+gflops NaN

--- a/linpack/openmetrics_linpack_reset.txt
+++ b/linpack/openmetrics_linpack_reset.txt
@@ -5,5 +5,5 @@ runtime NaN
 throughput NaN
 latency NaN
 hyper_thread NaN
-numb_sockets NaN
+num_sockets NaN
 gflops NaN


### PR DESCRIPTION
# Description
1) Adds code to save the test metrics to pcp openmetrics.
2) Add timestamps
3) Convert colon in csv file to be ,

# Before/After Comparison
Before: Test metrics only saved in csv file
After: Test metrics save in both csv file and pcp openmentrics.

# Clerical Stuff
This closes #30 

Relates to JIRA: RPOPC-774

Test results
=======================

command executed:
/home/ec2-user/workloads/linpack-wrapper/linpack/linpack_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.xlarge" --sysname "m7i.xlarge" --sys_type aws --use_pcp

csv file
ht_config,sockets,threads,unit,MB/sec,cpu_affin,Start_time,End_time,Start_Date,End_Date
ht_yes_1_socket,1,2,GFlops,182,0.1,2026-01-28T20:18:02Z,2026-01-28T20:18:39Z
ht_yes_1_socket,1,2,GFlops,175,2.3.0.1,2026-01-28T20:18:02Z,2026-01-28T20:18:39Z



====================================
pcp snippet

          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.hyper_thread  o.w.num_sockets  o.w.gflops
14:37:08          1.000        1.000           2.000          NaN             NaN          NaN             1.000            1.000     132.000
14:37:09          1.000        1.000           2.000          NaN             NaN          NaN             1.000            1.000     132.000
14:37:10          1.000        1.000           2.000          NaN             NaN          NaN             1.000            1.000     132.000

-x output
[linpack_x.txt](https://github.com/user-attachments/files/24768528/linpack_x.txt)


================================================================================
