### PR TITLE
Verify run results via pyantic.

### DIFF
--- a/linpack/linpack_extra/run_linpack.sh
+++ b/linpack/linpack_extra/run_linpack.sh
@@ -31,7 +31,6 @@ cpus_in_sock=""
 GOMP_CPU_AFFINITY=""
 NUMB_SOCKETS=""
 reduce_only=0
-test_name="linpack"
 test_version="1.0"
 start_time=""
 end_time=""
@@ -180,7 +179,7 @@ process_summary()
 	iters=0
 	input="/tmp/linpack_temp"
 
-	$TOOLS_BIN/test_header_info --front_matter --results_file results.csv  $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $test_version --test_name $test_name --field_header "ht_config,sockets,threads,unit,MB/sec,cpu_affin,Start_time,End_time"
+	$TOOLS_BIN/test_header_info --front_matter --results_file results_${test_name}.csv  $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $test_version --test_name $test_name --field_header "ht_config,sockets,threads,unit,MB_per_sec,cpu_affin"
 
 	while IFS= read -r lin_file
 	do
@@ -225,9 +224,8 @@ process_summary()
 		done < "$input1"
 		if [[ $avg  != "" ]]; then
 			test_results="Ran"
-			data_string=$(build_data_string "$ht_setting" "$sockets" "$threads" "$unit" "$avg" "$cpu_affin")
-
-			echo "$data_string" >> results.csv
+			data_string=$(build_data_string "$ht_setting" "$sockets" "$threads" "$unit" "$avg" "$cpu_affin" "$start_time" "$end_time")
+			echo "$data_string" >> results_${test_name}.csv
 		fi
 	done < "$input"
 

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -22,6 +22,9 @@
 # set of default run parameters based on the system configuration.
 #
 
+script_dir=$(realpath $(dirname $0))
+TOOLS_BIN="${HOME}"/test_tools
+export TOOLS_BIN
 error_exit()
 {
 	echo $1
@@ -32,11 +35,12 @@ usage()
 {
 	echo "$1 Usage:"
 	echo "  --interleave: numactl interleave option"
-	source test_tools/general_setup --usage
+	source ${TOOLS_BIN}/general_setup --usage
 	exit 1
 }
 
 test_name="linpack"
+export test_name
 if [ ! -f "/tmp/${test_name}.out" ]; then
         command="${0} $@"
         echo $command
@@ -104,8 +108,8 @@ done
 # Check to see if the test tools directory exists.  If it does, we do not need to
 # clone the repo.
 #
-if [ ! -d "test_tools" ]; then
-        git clone $tools_git test_tools
+if [ ! -d "${TOOLS_BIN}" ]; then
+        git clone $tools_git ${TOOLS_BIN}
         if [ $? -ne 0 ]; then
                 error_exit "pulling git $tools_git failed." 1
         fi
@@ -130,9 +134,7 @@ fi
 # to_tuned_setting: tuned setting
 #
 
-${curdir}/test_tools/gather_data ${curdir}
-source test_tools/general_setup "$@"
-export TOOLS_BIN
+source ${TOOLS_BIN}/general_setup "$@"
 
 execute_via_shell()
 {
@@ -228,7 +230,7 @@ fi
 chmod 755 ${run_dir}/linpack/xlinpack_xeon64
 
 # Gather hardware information
-${curdir}/test_tools/gather_data ${curdir}
+${TOOLS_BIN}/gather_data ${curdir}
 
 rm -rf $run_dir/linpack/linpack_results  $run_dir/linpack/results*
 
@@ -257,7 +259,7 @@ do
 	if [[ $to_use_pcp -eq 1 ]]; then
 		linpack_data=`mktemp /tmp/linpack_data.XXXXX`
 		results2pcp_add_value "iteration:${iteration}"
-		grep ^ht linpack_results/results.csv  | grep -v cpu_affin > $linpack_data
+		grep ^ht linpack_results/results_${test_name}.csv  | grep -v cpu_affin > $linpack_data
 		while IFS= read -r line
 		do
 			value=`echo $line | cut -d: -f1`
@@ -298,5 +300,9 @@ fi
 #
 # Process the data.
 #
-${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --results linpack_results/results.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "linpack_results/test_results_report,${curdir}/hw_info.out" $pdir
-exit 0
+${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file linpack_results/results_${test_name}.csv --output_file linpack_results/results_${test_name}.json
+${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Linpack_Results --file linpack_results/results_${test_name}.json
+rtc=$?
+
+${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --results linpack_results/results_${test_name}.csv --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user --other_files "linpack_results/test_results_report,${curdir}/hw_info.out" $pdir
+exit $rtc

--- a/linpack/results_schema.py
+++ b/linpack/results_schema.py
@@ -1,0 +1,14 @@
+import pydantic
+import datetime
+
+
+class Linpack_Results(pydantic.BaseModel):
+    ht_config: str
+    sockets: int = pydantic.Field(gt=0)
+    threads: int = pydantic.Field(gt=0)
+    unit: str
+    MB_per_sec: int = pydantic.Field(gt=0)
+    cpu_affin: str
+    Start_Date: datetime.datetime
+    End_Date: datetime.datetime
+


### PR DESCRIPTION
# Description
1) Verifies the run results using pyantics
2) Fixes how test_tools is created
3) Adds missing date stamps to csv file
4) Renames results.csv to be results_linpack.csv

# Before/After Comparison
Before: Results are not verified
After: Results are verified

# Clerical Stuff
This closes #32 

Relates to JIRA: RPOPC-820

Testing
Command executed
/home/ec2-user/workloads/linpack-wrapper/linpack/linpack_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m5.xlarge" --sysname "m5.xlarge" --sys_type aws  --use_pcp --interleave all --iterations 1

successful
csv output
ht_config,sockets,threads,unit,MB_per_sec,cpu_affin,Start_Date,End_Date
ht_yes_1_socket,1,2,GFlops,132,0.1,2026-02-06T11:23:04Z,2026-02-06T11:23:57Z
ht_yes_1_socket,1,2,GFlops,132,2.3.0.1,2026-02-06T11:23:04Z,2026-02-06T11:23:57Z

echo $?: 0

Induced error
Could not verify schema, see below for details
2 validation errors for list[Linpack_Results]
0.MB_per_sec
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='avg', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing
1.MB_per_sec
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='avg', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/int_parsing
updating: results_linpack_virtual-guest.tar (deflated 88%)
[root@ip-170-0-27-132 ec2-user]# echo $?
1


rtc: 0