### PR TITLE
Update error codes to be more specific.

### DIFF
--- a/linpack.json
+++ b/linpack.json
@@ -1,0 +1,28 @@
+{
+  "dependencies": {
+    "rhel": [
+      "bc",
+      "numactl",
+      "perf",
+      "unzip",
+      "git",
+      "zip"
+    ],
+    "ubuntu": [
+      "unzip",
+      "zip"
+    ],
+    "amzn": [
+      "bc",
+      "unzip",
+      "zip"
+    ],
+    "sles": [
+      "bc",
+      "libnuma1",
+      "git",
+      "unzip",
+      "zip"
+    ]
+  }
+}

--- a/linpack/linpack_extra/run_linpack.sh
+++ b/linpack/linpack_extra/run_linpack.sh
@@ -246,7 +246,7 @@ execute_linpack()
 		echo ./runN.sh -n $interleave -t ${OMP_NUM_THREADS} >> $out_file
 		./runN.sh -n $interleave -t ${OMP_NUM_THREADS} >> $out_file
 		if [ $? -ne 0 ]; then
-			exit_out "linpack execution failed 1" $E_GENERAL
+			exit_out "linpack execution failed" $E_GENERAL
 		fi
 	done
 }

--- a/linpack/linpack_extra/run_linpack.sh
+++ b/linpack/linpack_extra/run_linpack.sh
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 source $TOOLS_BIN/helpers.inc
+source $TOOLS_BIN/error_codes
 max_threads=0
 threads_to_do=0
 iterations=5
@@ -245,7 +246,7 @@ execute_linpack()
 		echo ./runN.sh -n $interleave -t ${OMP_NUM_THREADS} >> $out_file
 		./runN.sh -n $interleave -t ${OMP_NUM_THREADS} >> $out_file
 		if [ $? -ne 0 ]; then
-			exit_out "linpack execution failed 1" 1
+			exit_out "linpack execution failed 1" $E_GENERAL
 		fi
 	done
 }
@@ -261,7 +262,7 @@ usage()
 	echo "  -n: numactl interleave"
 	echo "  -s: sanity run"
 	echo "  -t: max threads: maximum number of threads"
-	exit 1
+	exit $E_USAGE
 }
 
 show_config=0
@@ -316,7 +317,7 @@ if [ $reduce_only -eq 1 ]; then
 	pushd /tmp
 	process_summary
 	popd
-	exit 0
+	exit $E_SUCCESS
 fi
 
 PREFIX=test
@@ -396,7 +397,7 @@ if [ $show_config -gt 0 ]; then
 			echo socket: $socket: ${cpus_in_sock[$socket]}
 		done
 	fi
-	exit 0
+	exit $E_SUCCESS
 fi
 
 
@@ -411,4 +412,4 @@ else
 fi
 
 process_summary
-exit 0
+exit $E_SUCCESS

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -167,6 +167,11 @@ fi
 #
 
 source ${TOOLS_BIN}/general_setup "$@"
+package_tool --no_packages $to_no_pkg_install --wrapper_config $script_dir/../linpack.json
+prtc=$?
+if [[ $prtc != 0 ]]; then
+	error_exit "Error: Installation of package issue" $prtc
+fi
 
 execute_via_shell()
 {

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -121,7 +121,7 @@ attempt_tools_wget()
         fi
 }
 
-attetmpt_tools_curl()
+attempt_tools_curl()
 {
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 curl -L -O ${tools_git}/archive/refs/heads/main.zip
@@ -144,7 +144,7 @@ attempt_tools_git()
 }
 
 attempt_tools_wget
-attetmpt_tools_curl
+attempt_tools_curl
 attempt_tools_git
 
 if [ $show_usage -eq 1 ]; then

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -36,7 +36,7 @@ usage()
 	echo "$1 Usage:"
 	echo "  --interleave: numactl interleave option"
 	source ${TOOLS_BIN}/general_setup --usage
-	exit 1
+	exit $E_USAGE
 }
 
 test_name="linpack"
@@ -138,7 +138,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        exit_out "Error: pulling git $tools_git failed." 1
+                        error_out "Error: pulling git $tools_git failed." $E_GENERAL
                 fi
         fi
 }
@@ -199,7 +199,7 @@ execute_via_shell()
 			echo ./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave
 			./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
 			if [ $? -ne 0 ]; then
-				error_exit "run_linpack.sh failed" 1
+				error_exit "run_linpack.sh failed" $E_GENERAL
 			fi
 		done  < "$file"
 	else
@@ -207,7 +207,7 @@ execute_via_shell()
 		echo ./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname  -n $interleave
 		./run_linpack.sh -u \"$to_user\" -h $to_home_root -C $to_configuration -i $to_times_to_run -P $to_tuned_setting -s $to_sysname -n $interleave >> $out_file
 		if [ $? -ne 0 ]; then
-			error_exit "run_linpack.sh failed" 1
+			error_exit "run_linpack.sh failed" $E_GENERAL
 		fi
 	fi
 }
@@ -252,7 +252,7 @@ while [[ $# -gt 0 ]]; do
 			break; 
 		;;
 		*)
-			error_exit "option not found $1" 1
+			error_exit "option not found $1" $E_PARSE_ARGS
 		;;
         esac
 done
@@ -262,7 +262,7 @@ if [[ ! -d "$run_dir/linpack" ]]; then
 fi
 cp ${curdir}/uploads/xlinpack_xeon64-NEW ${run_dir}/linpack/xlinpack_xeon64
 if [ $? -ne 0 ]; then
-	error_exit "Error, did not find xlinpack_xeon64-NEW" 1
+	error_exit "Error, did not find xlinpack_xeon64-NEW" $E_GENERAL
 fi
 chmod 755 ${run_dir}/linpack/xlinpack_xeon64
 

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -138,7 +138,7 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        error_out "Error: pulling git $tools_git failed." $E_GENERAL
+                        error_out "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }

--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -108,12 +108,44 @@ done
 # Check to see if the test tools directory exists.  If it does, we do not need to
 # clone the repo.
 #
-if [ ! -d "${TOOLS_BIN}" ]; then
-        git clone $tools_git ${TOOLS_BIN}
-        if [ $? -ne 0 ]; then
-                error_exit "pulling git $tools_git failed." 1
+
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
         fi
-fi
+}
+
+attetmpt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 1
+                fi
+        fi
+}
+
+attempt_tools_wget
+attetmpt_tools_curl
+attempt_tools_git
 
 if [ $show_usage -eq 1 ]; then
 	usage $test_name


### PR DESCRIPTION
# Description
Updates error codes to be more specific
Now uses the package_tool
New method of getting test tools

# Before/After Comparison
Before: Returned a 0 or 1, making determination of having to rerun very course.  Also before packaging fix, linpack would fail.  This is recent as the last of the packaging has been pulled.
After: Error codes are now bases on test_tools/error_codes, making it easier to limit when we do a rerun of the test.
Also, changed how we load in test_tools, we try curl, git, and wget, to avoid a failure due to the program not
being installed.

# Clerical Stuff
This closes #34 

Relates to JIRA: RPOPC-874

Testing 
Ran the following scenario 

global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: linpack_res
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "linpack"
    host_config: "m5.xlarge"


csv file
ht_config,sockets,threads,unit,MB_per_sec,cpu_affin,Start_Date,End_Date
ht_yes_1_socket,1,2,GFlops,133,0.1,2026-03-13T16:34:12Z,2026-03-13T16:35:04Z
ht_yes_1_socket,1,2,GFlops,133,2.3.0.1,2026-03-13T16:34:12Z,2026-03-13T16:35:04Z


Returned 0 as expected. Testing on rerun verification handled in the appropriate zathras pr.