### PR TITLE
Fix test_tools

### DIFF
--- a/linpack/linpack_run
+++ b/linpack/linpack_run
@@ -108,23 +108,11 @@ done
 # Check to see if the test tools directory exists.  If it does, we do not need to
 # clone the repo.
 #
-
-attempt_tools_wget()
+attempt_tools_generic()
 {
+	method="$1"
         if [[ ! -d "$TOOLS_BIN" ]]; then
-                wget ${tools_git}/archive/refs/heads/main.zip
-                if [[ $? -eq 0 ]]; then
-                        unzip -q main.zip
-                        mv test_tools-wrappers-main ${TOOLS_BIN}
-                        rm main.zip
-                fi
-        fi
-}
-
-attempt_tools_curl()
-{
-        if [[ ! -d "$TOOLS_BIN" ]]; then
-                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                $method ${tools_git}/archive/refs/heads/main.zip
                 if [[ $? -eq 0 ]]; then
                         unzip -q main.zip
                         mv test_tools-wrappers-main ${TOOLS_BIN}
@@ -138,13 +126,13 @@ attempt_tools_git()
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 git clone $tools_git "$TOOLS_BIN"
                 if [ $? -ne 0 ]; then
-                        error_out "Error: pulling git $tools_git failed." 101
+                        error_exit "Error: pulling git $tools_git failed." 101
                 fi
         fi
 }
 
-attempt_tools_wget
-attempt_tools_curl
+attempt_tools_generic "wget"
+attempt_tools_generic "curl -L -O "
 attempt_tools_git
 
 if [ $show_usage -eq 1 ]; then


### PR DESCRIPTION

# Description
1) Removes duplicate code in the test_tools new code
2) Fixes exit_out not existing

# Before/After Comparison
Before: If we failed, we would get an error calling exit_out as it does not exist.
After: Error no longer occurs.

# Clerical Stuff
This closes #36 

Relates to JIRA: RPOPC-900

Testing done:
Verified each method works, and we get a proper message if we fail.